### PR TITLE
Add user can view account details

### DIFF
--- a/server/controllers/v2/accountsControllerDb.js
+++ b/server/controllers/v2/accountsControllerDb.js
@@ -180,6 +180,42 @@ const Accounts = {
         }
         
         
+    },
+
+    async userViewAccount(req, res){
+        let userInfo = '';
+        jwt.verify(req.token, process.env.SECRET_OR_KEY, (err, authrizedData) =>{
+            if(err){
+                return res.status(403).send({
+                    status: 403,
+                    message: 'Forbidden access (403)'
+                });
+            } else {
+                userInfo = authrizedData;
+            }
+        });
+
+        const findAccount = 'SELECT * FROM accounts WHERE account_number = $1';
+        const { rows } = await db.query(findAccount, [req.params.accountNumber]);
+        if(rows[0]){
+            if(userInfo.email === rows[0].email){
+                return res.status(200).send({
+                    status: 200,
+                    message: `Account with number ${req.params.accountNumber} has been fetched successfully`,
+                    data: rows[0]
+                });
+            } else {
+                return res.status(403).send({
+                    status: 403,
+                    message: 'You can only view details of accounts you own'
+                });
+            }
+        } else {
+            return res.status(404).send({
+                status: 404,
+                message: `Account with number ${req.params.accountNumber} does not exist`
+            });
+        }
     }
 }
 

--- a/server/controllers/v2/transactionsControllerDb.js
+++ b/server/controllers/v2/transactionsControllerDb.js
@@ -166,7 +166,7 @@ const Transactions = {
 
     },
 
-    async getAccountTransactions(req, res){
+    async getTransactionHistory(req, res){
         let userEmail = '';
         jwt.verify(req.token, process.env.SECRET_OR_KEY, (err, authrizedData) => {
             if(err){
@@ -191,7 +191,7 @@ const Transactions = {
                 if(!rows[0]){
                     return res.status(404).send({
                         status: 404,
-                        message: 'No transactions have occured involving account'
+                        message: 'No transactions have occured involving your account'
                     });
                 } else {
                     return res.status(200).send({
@@ -215,11 +215,19 @@ const Transactions = {
 
     async viewSpecificTransaction(req, res){
         const userDetails = {
-            email : req.body.email,
-            password : req.body.password,
             id: req.params.id
         }
-
+        let userInfo = '';
+        jwt.verify(req.token, process.env.SECRET_OR_KEY, (err, authrizedData) => {
+            if(err){
+                return res.status(403).send({
+                    status: 403,
+                    message: 'Forbidden access'
+                });
+            } else {
+                userInfo = authrizedData;
+            }
+        });
         const allow = Joi.validate(userDetails, specificTransactionsSchema)
         if (allow.error){
             return res.status(400).send({
@@ -242,7 +250,7 @@ const Transactions = {
         
 
         const found = `SELECT * FROM users WHERE email = $1`;
-        const response = await db.query(found, [req.body.email]);
+        const response = await db.query(found, [userInfo.email]);
         if(!response.rows[0]){
             return res.status(404).send({
                 status: 404,

--- a/server/helpers/specificTransactionValidation.js
+++ b/server/helpers/specificTransactionValidation.js
@@ -2,12 +2,6 @@ import Joi from 'joi';
 
 const specificTransactionsSchema = Joi.object().keys({
     id: Joi.number().required(),
-    email: Joi.string().email().regex(/^[A-Za-z\._\-0-9]*[@][A-Za-z]*[\.][a-z]{2,4}$/).required(),
-    password: Joi.string().regex(/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,}$/).required().error( errors => {
-        return {
-            message: 'Your password is required and it should have at least one upper case English letter, one lower case English letter, one digit, one special character and a Minimum eight characters'
-        }
-    })
 });
 
 export default specificTransactionsSchema;

--- a/server/routes/api/v2/accountsDbRoutes.js
+++ b/server/routes/api/v2/accountsDbRoutes.js
@@ -8,5 +8,6 @@ accountsRouterDb.get('/accounts', checkToken, allAccountsDb.getAllaccounts);
 accountsRouterDb.post('/accounts', checkToken, allAccountsDb.createAccount);
 accountsRouterDb.patch('/accounts/:accountNumber', checkToken, allAccountsDb.accountActivateDeactivate);
 accountsRouterDb.delete('/accounts/:accountNumber', checkToken, allAccountsDb.deleteAccount);
+accountsRouterDb.get('/accounts/:accountNumber', checkToken, allAccountsDb.userViewAccount);
 
 export default accountsRouterDb;

--- a/server/routes/api/v2/transactionsDbRoutes.js
+++ b/server/routes/api/v2/transactionsDbRoutes.js
@@ -7,7 +7,7 @@ const transactionRoutesDb = Router();
 transactionRoutesDb.get('/transactions', checkToken, allTransactionsDb.getAllTransactions);
 transactionRoutesDb.post('/transactions/:accountNumber/credit', checkToken, allTransactionsDb.accountCredit);
 transactionRoutesDb.post('/transactions/:accountNumber/debit', checkToken, allTransactionsDb.accountDebit);
-transactionRoutesDb.get('/accounts/:accountNumber/transactions', checkToken, allTransactionsDb.getAccountTransactions);
+transactionRoutesDb.get('/accounts/:accountNumber/transactions', checkToken, allTransactionsDb.getTransactionHistory);
 transactionRoutesDb.get('/transactions/:id', checkToken, allTransactionsDb.viewSpecificTransaction);
 
 


### PR DESCRIPTION
**What does this PR do?**
 -This pull request adds an API endpoint which is responsible for allowing users to view account details of an account they own.

**Description of Task to be completed?**
 - This endpoint allows users to **only view**, but not edit accounts they **own**. 

**How should this be manually tested?**
- This endpoint can be tested manually using Postman. 
     1. ```git clone ssh:https://github.com/adafia/banka.git```
     2.  run ```npm install``` to install all project dependencies
     3. run ```npm run dev```



**Any background context you want to provide?**

N/A

**What are the relevant pivotal tracker stories?**

[#165431574](https://www.pivotaltracker.com/story/show/165431574)

**Screenshots **

N/A